### PR TITLE
[FUSEQE-18051] Workaround observability alerts

### DIFF
--- a/src/test/java/org/bf2/cos/e2e/tests/addon/AddonPodsTestITCase.java
+++ b/src/test/java/org/bf2/cos/e2e/tests/addon/AddonPodsTestITCase.java
@@ -54,10 +54,7 @@ public class AddonPodsTestITCase {
                             List<Pod> podList = client.pods().withLabelSelector(podSelector).list().getItems();
                             Assertions.assertEquals(podList.size(), 1, () -> podSelector + " pod not present");
                             PodResource<Pod> pod = client.pods().withName(podList.get(0).getMetadata().getName());
-                            Assertions.assertTrue(pod.isReady(), () ->{
-                                LOG.info("pod status: {}",  podList.get(0).getStatus());
-                                return podSelector + " pod not ready";
-                            });
+                            Assertions.assertTrue(pod.isReady(), () -> podSelector + " pod not ready");
                             reporter.publishEntry(Map.of(
                                     MetadataTestExecutionListener.REPORT_METADATA_CATEGORY_KEY, "pod",
                                     MetadataTestExecutionListener.REPORT_METADATA_ENTRY_KEY, podSelector,

--- a/src/test/java/org/bf2/cos/e2e/tests/addon/ObservabilityITCase.java
+++ b/src/test/java/org/bf2/cos/e2e/tests/addon/ObservabilityITCase.java
@@ -1,0 +1,67 @@
+package org.bf2.cos.e2e.tests.addon;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftConfig;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.*;
+
+import java.time.Duration;
+
+@Order(10)
+@Tags(value = {
+        @Tag("install")
+})
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ObservabilityITCase {
+
+    private static NamespacedOpenShiftClient client = new DefaultOpenShiftClient(new OpenShiftConfig(Config.autoConfigure(null)))
+            .inNamespace("redhat-openshift-connectors");
+
+    private static final CustomResourceDefinitionContext OBSERVABILITY_CONTEXT = new CustomResourceDefinitionContext.Builder()
+            .withName("Observability")
+            .withGroup("observability.redhat.com")
+            .withVersion("v1")
+            .withPlural("observabilities")
+            .withScope("Namespaced")
+            .build();
+
+    @Test
+    @Order(1)
+    @DisplayName("observability custom resource should be created")
+    public void observabilityCustomResourceShouldBeCreated() {
+        Awaitility.await()
+                .atMost(Duration.ofMinutes(3))
+                .untilAsserted(() -> Assertions.assertNotNull(client.genericKubernetesResources(OBSERVABILITY_CONTEXT)
+                        .withName("rhoc-observability-stack").get())
+                );
+        // TODO: check the custom resource values as well
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("observability namespace should be created")
+    public void observabilityNamespaceShouldBeCreated() {
+        Awaitility.await()
+                .atMost(Duration.ofMinutes(3))
+                .untilAsserted(() -> Assertions.assertNotNull(client.namespaces().withName("redhat-openshift-connectors-observability").get()));
+        // TODO: check the pods in the namespace are running
+    }
+
+    @AfterAll
+    public static void deleteObservabilityNamespace() {
+        // this is a hack to prevent noise in pagerduty
+        var obsCrd = client.genericKubernetesResources(OBSERVABILITY_CONTEXT)
+                .withName("rhoc-observability-stack");
+        obsCrd.delete();
+        var obsNs = client.namespaces().withName("redhat-openshift-connectors-observability");
+        obsNs.delete();
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofSeconds(2))
+                .pollDelay(Duration.ofSeconds(0))
+                .until(() -> obsNs.get() == null);
+    }
+}


### PR DESCRIPTION
Adds an initial observability test (only checks the crd and ns present),
and deletes the observability resources at the end of tests, to prevent
bogus alerts in pagerduty.